### PR TITLE
Add option for output dir

### DIFF
--- a/full_config.yaml
+++ b/full_config.yaml
@@ -34,6 +34,9 @@ TightTicker: true
 # Protocol defaults to HTTP/1.1, HTTP/2 is also supported
 Protocol: HTTP/2
 
+# Directory to write the output report to. Defaults to 'out'
+Outdir: "out"
+
 Request:
   # HTTPMethod defaults to GET if Body (below) is not present and to POST otherwise, but can be specified explicitly
   HTTPMethod: POST

--- a/full_config.yaml
+++ b/full_config.yaml
@@ -34,8 +34,8 @@ TightTicker: true
 # Protocol defaults to HTTP/1.1, HTTP/2 is also supported
 Protocol: HTTP/2
 
-# Directory to write the output report to. Defaults to 'out'
-OutDir: "out"
+# File to write the output report to. Defaults to 'out/res.hgram'
+OutFile: "out/res.hgram"
 
 Request:
   # HTTPMethod defaults to GET if Body (below) is not present and to POST otherwise, but can be specified explicitly

--- a/full_config.yaml
+++ b/full_config.yaml
@@ -35,7 +35,7 @@ TightTicker: true
 Protocol: HTTP/2
 
 # Directory to write the output report to. Defaults to 'out'
-Outdir: "out"
+OutDir: "out"
 
 Request:
   # HTTPMethod defaults to GET if Body (below) is not present and to POST otherwise, but can be specified explicitly

--- a/full_config.yaml
+++ b/full_config.yaml
@@ -34,8 +34,8 @@ TightTicker: true
 # Protocol defaults to HTTP/1.1, HTTP/2 is also supported
 Protocol: HTTP/2
 
-# File to write the output report to. Defaults to 'out/res.hgram'
-OutFile: "out/res.hgram"
+# File to write the output report to. Defaults to 'out/res.hgrm'
+OutFile: "out/res.hgrm"
 
 Request:
   # HTTPMethod defaults to GET if Body (below) is not present and to POST otherwise, but can be specified explicitly

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ type config struct {
 	Params   benchParams         `yaml:",inline"`
 	Protocol string              `yaml:"Protocol"`
 	Request  WebRequesterFactory `yaml:"Request"`
-	Output   string              `yaml:"OutDir"`
+	Output   string              `yaml:"OutFile"`
 }
 
 func maybePanic(err error) {
@@ -109,14 +109,14 @@ func main() {
 
 	fmt.Println(summary)
 
-	outdir := conf.Output
-	if outdir == "" {
-		outdir = "out"
+	outfile := conf.Output
+	if outfile == "" {
+		outfile = "out/res.hgrm"
 	}
 
-	err = os.MkdirAll(outdir, os.ModeDir|os.ModePerm)
+	err = os.MkdirAll(path.Dir(outfile), os.ModeDir|os.ModePerm)
 	maybePanic(err)
 
-	err = summary.GenerateLatencyDistribution(bench.Logarithmic, path.Join("out", "res.hgrm"))
+	err = summary.GenerateLatencyDistribution(bench.Logarithmic, outfile)
 	maybePanic(err)
 }

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ type config struct {
 	Params   benchParams         `yaml:",inline"`
 	Protocol string              `yaml:"Protocol"`
 	Request  WebRequesterFactory `yaml:"Request"`
+	Output   string              `yaml:"OutDir"`
 }
 
 func maybePanic(err error) {
@@ -108,7 +109,12 @@ func main() {
 
 	fmt.Println(summary)
 
-	err = os.MkdirAll("out", os.ModeDir|os.ModePerm)
+	outdir := conf.Output
+	if outdir == "" {
+		outdir = "out"
+	}
+
+	err = os.MkdirAll(outdir, os.ModeDir|os.ModePerm)
 	maybePanic(err)
 
 	err = summary.GenerateLatencyDistribution(bench.Logarithmic, path.Join("out", "res.hgrm"))


### PR DESCRIPTION
Add option for output dir.

Allowing output dir to be configured makes it easier to compare across multiple different endpoints. 